### PR TITLE
emacs: don't display gravatar on macOS

### DIFF
--- a/emacs.d/init.el
+++ b/emacs.d/init.el
@@ -677,8 +677,9 @@
         magit-repository-directories '(("~/dev" . 1))
         magit-tag-arguments '("--annotate")
         magit-fetch-arguments '("--prune")
-        magit-revision-show-gravatars '("^Author:     " . "^Commit:     ")
         magit-diff-refine-hunk 'all)
+  (unless (eq system-type 'darwin)
+    (setq magit-revision-show-gravatars '("^Author:     " . "^Commit:     ")))
   (remove-hook 'magit-pre-display-buffer-hook #'magit-save-window-configuration))
 
 (use-package magit-gitflow


### PR DESCRIPTION
See https://github.com/magit/magit/issues/2265

Magit provides a workaround for this issue, but images look bad even with the workaround enabled.