### PR TITLE
emacs: add langtool

### DIFF
--- a/emacs.d/init.el
+++ b/emacs.d/init.el
@@ -821,6 +821,11 @@ _M-p_: Unmark  _M-n_: Unmark  _q_: Quit"
   :ensure
   :config (wrap-region-global-mode 1))
 
+(use-package langtool
+  :ensure
+  :bind (:map text-mode-map
+              ("C-c l" . langtool-check)))
+
 (use-package yasnippet
   :ensure
   :config


### PR DESCRIPTION
This package provides integration with the LanguageTool grammar checker. It requires LanguageTool, but will not interfere the user if it isn't installed.