### PR TITLE
emacs: add EIN

### DIFF
--- a/emacs.d/init.el
+++ b/emacs.d/init.el
@@ -32,6 +32,10 @@
   (push zplug-bin exec-path)
   (setenv "PATH" (concat zplug-bin path-separator (getenv "PATH"))))
 
+(defgroup my/configuration nil
+  "Configuration customizations"
+  :group 'convenience)
+
 (unless (file-exists-p custom-file)
   (write-region "" nil custom-file))
 (load custom-file)
@@ -435,6 +439,25 @@
   (unbind-key "C-c C-f" python-mode-map)
   (advice-add #'python-indent-shift-left :around #'my/python-shift-region)
   (advice-add #'python-indent-shift-right :around #'my/python-shift-region))
+
+(use-package ein
+  :ensure
+  :preface
+  (defcustom my/jupyter-daemon-url "http://localhost:8888"
+    "URL for the Jupyter notebook daemon"
+    :type 'string
+    :group 'my/configuration)
+  (defcustom my/jupyter-daemon-password nil
+    "Password for the Jupyter notebook daemon"
+    :type 'string
+    :group 'my/configuration)
+  :bind ("<f6>" . my/open-jupyter-notebook)
+  :config
+  (with-eval-after-load "ein-cell"
+    (set-face-attribute 'ein:cell-input-area nil :background nil)
+    (set-face-attribute 'ein:cell-input-prompt nil :inherit 'highlight)
+    (set-face-attribute 'ein:cell-output-prompt nil :inherit 'doom-modeline-error))
+  (add-hook 'ein:notebook-mode-hook #'my/disable-auto-completion))
 
 (use-package hy-mode
   :ensure

--- a/emacs.d/lisp/config-defuns-autoloads.el
+++ b/emacs.d/lisp/config-defuns-autoloads.el
@@ -3,8 +3,8 @@
 ;;; Code:
 
 
-;;;### (autoloads nil "config-defuns" "config-defuns.el" (22969 36393
-;;;;;;  0 0))
+;;;### (autoloads nil "config-defuns" "config-defuns.el" (23013 49205
+;;;;;;  412908 564000))
 ;;; Generated autoloads from config-defuns.el
 
 (autoload 'my/cleanup-buffer "config-defuns" "\
@@ -252,6 +252,16 @@ the line in which the beginning of the mark is found.  END and
 COUNT are set in the same way as the original function.
 
 \(fn FN START END &optional COUNT)" t nil)
+
+(autoload 'my/open-jupyter-notebook "config-defuns" "\
+Open the Jupyter notebook configured in my/jupyter-daemon-url.  Log in if necessary.
+
+\(fn)" t nil)
+
+(autoload 'my/disable-auto-completion "config-defuns" "\
+Disable auto completion.
+
+\(fn)" nil nil)
 
 ;;;***
 

--- a/emacs.d/lisp/config-defuns.el
+++ b/emacs.d/lisp/config-defuns.el
@@ -444,6 +444,24 @@ COUNT are set in the same way as the original function."
      (list (line-beginning-position) (line-end-position) current-prefix-arg)))
   (apply fn start end count))
 
+(defvar my/logged-in-to-jupyter nil)
+
+;;;###autoload
+(defun my/open-jupyter-notebook ()
+  "Open the Jupyter notebook configured in my/jupyter-daemon-url.  Log in if necessary."
+  (interactive)
+  (unless my/logged-in-to-jupyter
+    (let ((password (or my/jupyter-daemon-password (read-passwd "Password: "))))
+      (ein:notebooklist-login my/jupyter-daemon-url password)
+      (setq my/logged-in-to-jupyter t)))
+  (ein:notebooklist-open my/jupyter-daemon-url))
+
+;;;###autoload
+(defun my/disable-auto-completion ()
+  "Disable auto completion."
+  (company-mode 0)
+  (auto-complete-mode 0))
+
 (provide 'config-defuns)
 
 ;;; Local Variables:


### PR DESCRIPTION
This patch adds the EIN package, as well as some other customization.

EIN doesn't really fit into the workflow of a single Jupyter daemon which is always open, so we
added my/open-jupyter-notebook to help with that. It reads the URL of the Jupyter notebook from the
customization file, log in if necessary and then open the notebook.

We also set some of its faces in order to better fit the Doom theme.

In addition, we disable Emacs's auto completion, as it behaves strangely in EIN. Completion is done
either by typing the . character after an object, or by pressing C-c TAB.