### PR TITLE
Use local eslint if possible

### DIFF
--- a/emacs.d/init.el
+++ b/emacs.d/init.el
@@ -347,6 +347,7 @@
   :ensure
   :demand
   :bind ("M-<f8>" . flycheck-list-errors)
+  :hook (flycheck-mode . my/use-eslint-from-node-modules)
   :config
   (setq flycheck-indication-mode 'right-fringe
         flycheck-emacs-lisp-load-path 'inherit)
@@ -817,6 +818,9 @@ _M-p_: Unmark  _M-n_: Unmark  _q_: Quit"
 
 (use-package js2-mode
   :ensure
+  :config
+  (setq js2-mode-show-parse-errors nil
+        js2-mode-show-strict-warnings nil)
   :mode "\\.js\\'")
 
 (use-package winner

--- a/emacs.d/lisp/config-defuns.el
+++ b/emacs.d/lisp/config-defuns.el
@@ -448,6 +448,17 @@ COUNT are set in the same way as the original function."
   (interactive "p")
   (scroll-down n))
 
+(defun my/use-eslint-from-node-modules ()
+  "Use local eslint from node_modules before global."
+  (let* ((root (locate-dominating-file
+                (or (buffer-file-name) default-directory)
+                "node_modules"))
+         (eslint (and root
+                      (expand-file-name "node_modules/eslint/bin/eslint.js"
+                                        root))))
+    (when (and eslint (file-executable-p eslint))
+      (setq-local flycheck-javascript-eslint-executable eslint))))
+
 (provide 'config-defuns)
 
 ;;; Local Variables:


### PR DESCRIPTION
This patch is similar to how we use pyvenv in order to execute the virtualenv's pylint instead of
the global one.

The code was taken from this blog post:
http://codewinds.com/blog/2015-04-02-emacs-flycheck-eslint-jsx.html

In addition, I disabled js2-mode's built-in error check as it is inferior to eslint.