### PR TITLE
Use exec-path-from-shell on Mac OS X

### DIFF
--- a/emacs.d/init.el
+++ b/emacs.d/init.el
@@ -97,6 +97,11 @@
 (bind-key "M-p" #'my/scroll-down)
 (bind-key "M-n" #'my/scroll-up)
 
+(use-package exec-path-from-shell
+  :ensure
+  :if (eq system-type 'darwin)
+  :config (exec-path-from-shell-initialize))
+
 (use-package mwim
   :ensure
   :bind (("<home>" . mwim-beginning)


### PR DESCRIPTION
This fixes an issue where rg fails to run because of missing path components coming from homebrew