### PR TITLE
Disable all-the-icons in Windows

### DIFF
--- a/emacs.d/lisp/config-looks.el
+++ b/emacs.d/lisp/config-looks.el
@@ -40,6 +40,7 @@
 (use-package spaceline-all-the-icons
   :ensure
   :config
+  :when (not (eq system-type 'windows-nt))
   (setq spaceline-all-the-icons-primary-separator ""
         spaceline-all-the-icons-secondary-separator ""
         spaceline-all-the-icons-separator-type 'none


### PR DESCRIPTION
It causes a major performance penalty:
https://github.com/domtronn/spaceline-all-the-icons.el/issues/9