### PR TITLE
Use bash for git installations

### DIFF
--- a/install-git.sh
+++ b/install-git.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 if [ -z $1 ]; then
     repo_path=$(dirname $(realpath $0))


### PR DESCRIPTION
macOS has a version of sh which doesn't understand the -e flag, so it just echos "-e [include]" into the configuration file.