### PR TITLE
Fix gitconfig

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -17,6 +17,7 @@
     lpw = log --patch --color-words
     ls = log --stat
     pr = !git co master && git pull && git co @{-1} && git rb master
+    rb = rebase
     ri = rebase -i
     st = status
     unstage = reset --


### PR DESCRIPTION
The `pr` alias on the line above fails, because `git rb` is not defined.